### PR TITLE
Add file preview and manual download

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,14 @@
 import React from 'react';
-import {Button, Card, Col, Input, Menu, MenuProps, message, Row, Space, Typography, Upload, UploadFile, Layout} from "antd";
-import {CopyOutlined, UploadOutlined} from "@ant-design/icons";
+import {Button, Card, Col, Input, Menu, MenuProps, message, Row, Space, Typography, Upload, UploadFile, Layout, List} from "antd";
+import {CopyOutlined, UploadOutlined, DownloadOutlined} from "@ant-design/icons";
 import ThemeToggle from './theme/ThemeToggle';
 import {useAppDispatch, useAppSelector} from "./store/hooks";
 import {startPeer, stopPeerSession} from "./store/peer/peerActions";
 import * as connectionAction from "./store/connection/connectionActions"
 import {DataType, PeerConnection} from "./helpers/peer";
 import {useAsyncState} from "./helpers/hooks";
+import download from "js-file-download";
+import {ReceivedFile} from "./store/connection/connectionTypes";
 
 const {Title} = Typography
 type MenuItem = Required<MenuProps>['items'][number]
@@ -31,6 +33,7 @@ export const App: React.FC = () => {
 
     const peer = useAppSelector((state) => state.peer)
     const connection = useAppSelector((state) => state.connection)
+    const receivedFiles = connection.receivedFiles
     const dispatch = useAppDispatch()
 
     const handleStartSession = () => {
@@ -76,6 +79,10 @@ export const App: React.FC = () => {
             console.log(err)
             message.error("Error when sending file")
         }
+    }
+
+    const handleDownload = (file: ReceivedFile) => {
+        download(file.file, file.fileName, file.fileType)
     }
 
     return (
@@ -144,8 +151,27 @@ export const App: React.FC = () => {
                                     loading={sendLoading}
                                     style={{marginTop: 16}}
                                 >
-                                    {sendLoading ? 'Sending' : 'Send'}
+                                {sendLoading ? 'Sending' : 'Send'}
                                 </Button>
+                            </Card>
+                            <Card title="Received Files" style={{marginTop: 16}}>
+                                {
+                                    receivedFiles.length === 0
+                                        ? <div>No file received</div>
+                                        : <List
+                                            dataSource={receivedFiles}
+                                            renderItem={(item: ReceivedFile) => (
+                                                <List.Item
+                                                    actions={[<Button icon={<DownloadOutlined/>} onClick={() => handleDownload(item)}>Download</Button>]}
+                                                >
+                                                    <List.Item.Meta
+                                                        title={item.fileName}
+                                                        description={`from ${item.from}`}
+                                                    />
+                                                </List.Item>
+                                            )}
+                                        />
+                                }
                             </Card>
                         </div>
                     </Card>

--- a/src/store/connection/connectionActions.ts
+++ b/src/store/connection/connectionActions.ts
@@ -1,8 +1,7 @@
-import {ConnectionActionType} from "./connectionTypes";
+import {ConnectionActionType, ReceivedFile} from "./connectionTypes";
 import {Dispatch} from "redux";
 import {DataType, PeerConnection} from "../../helpers/peer";
 import {message} from "antd";
-import download from "js-file-download";
 
 export const changeConnectionInput = (id: string) => ({
     type: ConnectionActionType.CONNECTION_INPUT_CHANGE, id
@@ -23,6 +22,10 @@ export const selectItem = (id: string) => ({
     type: ConnectionActionType.CONNECTION_ITEM_SELECT, id
 })
 
+export const addReceivedFile = (file: ReceivedFile) => ({
+    type: ConnectionActionType.RECEIVED_FILE_ADD, file
+})
+
 export const connectPeer: (id: string) => (dispatch: Dispatch) => Promise<void>
     = (id: string) => (async (dispatch) => {
     dispatch(setLoading(true))
@@ -34,8 +37,14 @@ export const connectPeer: (id: string) => (dispatch: Dispatch) => Promise<void>
         })
         PeerConnection.onConnectionReceiveData(id, (file) => {
             message.info("Receiving file " + file.fileName + " from " + id)
-            if (file.dataType === DataType.FILE) {
-                download(file.file || '', file.fileName || "fileName", file.fileType)
+            if (file.dataType === DataType.FILE && file.file) {
+                const received: ReceivedFile = {
+                    from: id,
+                    file: file.file,
+                    fileName: file.fileName || 'fileName',
+                    fileType: file.fileType || ''
+                }
+                dispatch(addReceivedFile(received))
             }
         })
         dispatch(addConnectionList(id))

--- a/src/store/connection/connectionReducer.ts
+++ b/src/store/connection/connectionReducer.ts
@@ -5,7 +5,8 @@ export const initialState: ConnectionState = {
     id: undefined,
     loading: false,
     list: [],
-    selectedId: undefined
+    selectedId: undefined,
+    receivedFiles: []
 }
 
 export const ConnectionReducer: Reducer<ConnectionState> = (state = initialState, action) => {
@@ -33,6 +34,9 @@ export const ConnectionReducer: Reducer<ConnectionState> = (state = initialState
         return {...state, list: newList}
     } else if (action.type === ConnectionActionType.CONNECTION_ITEM_SELECT) {
         return {...state, selectedId: action.id}
+    } else if (action.type === ConnectionActionType.RECEIVED_FILE_ADD) {
+        const {file} = action
+        return {...state, receivedFiles: [...state.receivedFiles, file]}
     } else {
         return state
     }

--- a/src/store/connection/connectionTypes.ts
+++ b/src/store/connection/connectionTypes.ts
@@ -3,7 +3,8 @@ export enum ConnectionActionType {
     CONNECTION_CONNECT_LOADING = 'CONNECTION_CONNECT_LOADING',
     CONNECTION_LIST_ADD = 'CONNECTION_LIST_ADD',
     CONNECTION_LIST_REMOVE = 'CONNECTION_LIST_REMOVE',
-    CONNECTION_ITEM_SELECT = 'CONNECTION_ITEM_SELECT'
+    CONNECTION_ITEM_SELECT = 'CONNECTION_ITEM_SELECT',
+    RECEIVED_FILE_ADD = 'RECEIVED_FILE_ADD'
 }
 
 export interface ConnectionState {
@@ -11,4 +12,12 @@ export interface ConnectionState {
     readonly loading: boolean
     readonly list: string[]
     readonly selectedId?: string
+    readonly receivedFiles: ReceivedFile[]
+}
+
+export interface ReceivedFile {
+    readonly from: string
+    readonly file: Blob
+    readonly fileName: string
+    readonly fileType: string
 }

--- a/src/store/peer/peerActions.ts
+++ b/src/store/peer/peerActions.ts
@@ -2,8 +2,7 @@ import {PeerActionType} from "./peerTypes";
 import {Dispatch} from "redux";
 import {DataType, PeerConnection} from "../../helpers/peer";
 import {message} from "antd";
-import {addConnectionList, removeConnectionList} from "../connection/connectionActions";
-import download from "js-file-download";
+import {addConnectionList, removeConnectionList, addReceivedFile} from "../connection/connectionActions";
 
 export const startPeerSession = (id: string) => ({
     type: PeerActionType.PEER_SESSION_START, id
@@ -31,8 +30,14 @@ export const startPeer: () => (dispatch: Dispatch) => Promise<void>
             })
             PeerConnection.onConnectionReceiveData(peerId, (file) => {
                 message.info("Receiving file " + file.fileName + " from " + peerId)
-                if (file.dataType === DataType.FILE) {
-                    download(file.file || '', file.fileName || "fileName", file.fileType)
+                if (file.dataType === DataType.FILE && file.file) {
+                    const received = {
+                        from: peerId,
+                        file: file.file,
+                        fileName: file.fileName || 'fileName',
+                        fileType: file.fileType || ''
+                    }
+                    dispatch(addReceivedFile(received))
                 }
             })
         })


### PR DESCRIPTION
## Summary
- add `ReceivedFile` type and new reducer state
- store received files and expose new action
- update peer actions to store incoming files
- display received files list with download buttons

## Testing
- `yarn test --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68418b211268832fb74f4de618b19c43