### PR TITLE
Implement chunked file transfer with caching

### DIFF
--- a/src/helpers/fileCache.ts
+++ b/src/helpers/fileCache.ts
@@ -1,0 +1,27 @@
+import {openDB} from 'idb';
+
+const dbPromise = openDB('nebula-transfer', 1, {
+  upgrade(db) {
+    db.createObjectStore('files');
+  }
+});
+
+export async function cacheChunk(fileId: string, index: number, chunk: ArrayBuffer) {
+  const db = await dbPromise;
+  await db.put('files', chunk, `${fileId}-${index}`);
+}
+
+export async function readChunk(fileId: string, index: number): Promise<ArrayBuffer | undefined> {
+  const db = await dbPromise;
+  return db.get('files', `${fileId}-${index}`);
+}
+
+export async function assembleFile(fileId: string, total: number, fileType: string): Promise<Blob> {
+  const db = await dbPromise;
+  const chunks: ArrayBuffer[] = [];
+  for (let i = 0; i < total; i++) {
+    const chunk = await db.get('files', `${fileId}-${i}`);
+    if (chunk) chunks.push(chunk);
+  }
+  return new Blob(chunks, {type: fileType});
+}

--- a/src/store/connection/connectionActions.ts
+++ b/src/store/connection/connectionActions.ts
@@ -2,6 +2,7 @@ import {ConnectionActionType, ReceivedFile} from "./connectionTypes";
 import {Dispatch} from "redux";
 import {DataType, PeerConnection} from "../../helpers/peer";
 import {message} from "antd";
+import {cacheChunk} from "../../helpers/fileCache";
 
 export const changeConnectionInput = (id: string) => ({
     type: ConnectionActionType.CONNECTION_INPUT_CHANGE, id
@@ -26,6 +27,14 @@ export const addReceivedFile = (file: ReceivedFile) => ({
     type: ConnectionActionType.RECEIVED_FILE_ADD, file
 })
 
+export const updateFileProgress = (id: string, received: number) => ({
+    type: ConnectionActionType.RECEIVED_FILE_PROGRESS, id, received
+})
+
+export const markFileReady = (id: string) => ({
+    type: ConnectionActionType.RECEIVED_FILE_READY, id
+})
+
 export const connectPeer: (id: string) => (dispatch: Dispatch) => Promise<void>
     = (id: string) => (async (dispatch) => {
     dispatch(setLoading(true))
@@ -35,16 +44,43 @@ export const connectPeer: (id: string) => (dispatch: Dispatch) => Promise<void>
             message.info("Connection closed: " + id)
             dispatch(removeConnectionList(id))
         })
-        PeerConnection.onConnectionReceiveData(id, (file) => {
-            message.info("Receiving file " + file.fileName + " from " + id)
-            if (file.dataType === DataType.FILE && file.file) {
+        PeerConnection.onConnectionReceiveData(id, async (data) => {
+            if (data.dataType === DataType.FILE_META) {
+                const total = data.total || 0
+                const size = Number(data.message || '0')
+                const fileId = `${id}-${data.fileName}`
                 const received: ReceivedFile = {
+                    id: fileId,
                     from: id,
-                    file: file.file,
-                    fileName: file.fileName || 'fileName',
-                    fileType: file.fileType || ''
+                    fileName: data.fileName || 'fileName',
+                    fileType: data.fileType || '',
+                    size,
+                    chunks: total,
+                    received: 0,
+                    ready: false
                 }
                 dispatch(addReceivedFile(received))
+            } else if (data.dataType === DataType.FILE_CHUNK && data.chunk !== undefined && data.index !== undefined) {
+                const fileId = `${id}-${data.fileName}`
+                await cacheChunk(fileId, data.index, data.chunk)
+                dispatch(updateFileProgress(fileId, data.index + 1))
+            } else if (data.dataType === DataType.FILE_COMPLETE) {
+                const fileId = `${id}-${data.fileName}`
+                dispatch(markFileReady(fileId))
+            } else if (data.dataType === DataType.FILE && data.file) {
+                const fileId = `${id}-${data.fileName}`
+                const received: ReceivedFile = {
+                    id: fileId,
+                    from: id,
+                    fileName: data.fileName || 'fileName',
+                    fileType: data.fileType || '',
+                    size: data.file.size,
+                    chunks: 1,
+                    received: 1,
+                    ready: true
+                }
+                dispatch(addReceivedFile(received))
+                await cacheChunk(fileId, 0, await data.file.arrayBuffer())
             }
         })
         dispatch(addConnectionList(id))

--- a/src/store/connection/connectionReducer.ts
+++ b/src/store/connection/connectionReducer.ts
@@ -37,6 +37,14 @@ export const ConnectionReducer: Reducer<ConnectionState> = (state = initialState
     } else if (action.type === ConnectionActionType.RECEIVED_FILE_ADD) {
         const {file} = action
         return {...state, receivedFiles: [...state.receivedFiles, file]}
+    } else if (action.type === ConnectionActionType.RECEIVED_FILE_PROGRESS) {
+        const {id, received} = action
+        const receivedFiles = state.receivedFiles.map(f => f.id === id ? {...f, received} : f)
+        return {...state, receivedFiles}
+    } else if (action.type === ConnectionActionType.RECEIVED_FILE_READY) {
+        const {id} = action
+        const receivedFiles = state.receivedFiles.map(f => f.id === id ? {...f, ready: true} : f)
+        return {...state, receivedFiles}
     } else {
         return state
     }

--- a/src/store/connection/connectionTypes.ts
+++ b/src/store/connection/connectionTypes.ts
@@ -4,7 +4,9 @@ export enum ConnectionActionType {
     CONNECTION_LIST_ADD = 'CONNECTION_LIST_ADD',
     CONNECTION_LIST_REMOVE = 'CONNECTION_LIST_REMOVE',
     CONNECTION_ITEM_SELECT = 'CONNECTION_ITEM_SELECT',
-    RECEIVED_FILE_ADD = 'RECEIVED_FILE_ADD'
+    RECEIVED_FILE_ADD = 'RECEIVED_FILE_ADD',
+    RECEIVED_FILE_PROGRESS = 'RECEIVED_FILE_PROGRESS',
+    RECEIVED_FILE_READY = 'RECEIVED_FILE_READY'
 }
 
 export interface ConnectionState {
@@ -16,8 +18,12 @@ export interface ConnectionState {
 }
 
 export interface ReceivedFile {
+    readonly id: string
     readonly from: string
-    readonly file: Blob
     readonly fileName: string
     readonly fileType: string
+    readonly size: number
+    readonly chunks: number
+    readonly received: number
+    readonly ready: boolean
 }


### PR DESCRIPTION
## Summary
- add `fileCache` helper for chunk storage using IndexedDB
- extend PeerConnection with large file transfer methods
- track received file progress in Redux state
- update UI to show progress and download after caching

## Testing
- `yarn test`
- `yarn build` *(fails: Browserslist outdated messages; build aborted)*

------
https://chatgpt.com/codex/tasks/task_e_684191f759d4832fbe5dfa00d3e10e12