### PR TITLE
Fix build errors for QR code imports

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,7 +11,7 @@ import {assembleFile} from "./helpers/fileCache";
 import {useAsyncState} from "./helpers/hooks";
 import download from "js-file-download";
 import {ReceivedFile} from "./store/connection/connectionTypes";
-import QRCode from 'qrcode.react';
+import { QRCodeSVG } from 'qrcode.react';
 import QrScanner from 'react-qr-scanner';
 
 const {Title} = Typography
@@ -114,7 +114,7 @@ export const App: React.FC = () => {
                                     }}/>
                                     <Button danger onClick={handleStopSession}>Stop</Button>
                                 </Space>
-                                <QRCode value={peer.id || ''} size={128} />
+                                <QRCodeSVG value={peer.id || ''} size={128} />
                             </Space>
                         </Card>
                         <div hidden={!peer.started}>

--- a/src/react-qr-scanner.d.ts
+++ b/src/react-qr-scanner.d.ts
@@ -1,0 +1,1 @@
+declare module 'react-qr-scanner';


### PR DESCRIPTION
## Summary
- use QRCodeSVG named export from `qrcode.react`
- add TypeScript declaration for `react-qr-scanner`

## Testing
- `npm test -- --watchAll=false --passWithNoTests`
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_6841ab33a730832faf4f0c487f84326d