### PR TITLE
Fix PIN persistence and QR scan UX

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -49,8 +49,9 @@ export const App: React.FC = () => {
         dispatch(stopPeerSession())
     }
 
-    const handleConnectOtherPeer = () => {
-        connection.id != null ? dispatch(connectionAction.connectPeer(connection.id || "")) : message.warning("Please enter ID")
+    const handleConnectOtherPeer = (targetId?: string) => {
+        const id = targetId ?? connection.id
+        id ? dispatch(connectionAction.connectPeer(id)) : message.warning("Please enter ID")
     }
 
     const [fileList, setFileList] = useAsyncState([] as UploadFile[])
@@ -74,10 +75,10 @@ export const App: React.FC = () => {
             })
             await setSendLoading(false)
             message.info("Send file successfully")
-        } catch (err) {
+        } catch (err: any) {
             await setSendLoading(false)
             console.log(err)
-            message.error("Error when sending file")
+            message.error(err?.message || "Error when sending file")
         }
     }
 
@@ -130,12 +131,14 @@ export const App: React.FC = () => {
                                     <div style={{marginTop: 16}}>
                                         <QrScanner
                                             delay={300}
+                                            facingMode="front"
                                             onError={() => setScanOpen(false)}
                                             onScan={(data: any) => {
                                                 if (data) {
-                                                    dispatch(connectionAction.changeConnectionInput(data.text))
+                                                    const scanned = data.text
+                                                    dispatch(connectionAction.changeConnectionInput(scanned))
                                                     setScanOpen(false)
-                                                    handleConnectOtherPeer()
+                                                    handleConnectOtherPeer(scanned)
                                                 }
                                             }}
                                             style={{width: '100%'}}

--- a/src/helpers/peer.ts
+++ b/src/helpers/peer.ts
@@ -140,7 +140,7 @@ export const PeerConnection = {
     ) => {
         const total = Math.ceil(file.size / chunkSize)
         const pin = Math.floor(100000 + Math.random() * 900000).toString()
-        message.info(`PIN for transfer: ${pin}`)
+        const hidePin = message.info(`PIN for transfer: ${pin}`, 0)
         await PeerConnection.sendConnection(id, {
             dataType: DataType.FILE_REQUEST,
             fileName: file.name,
@@ -163,6 +163,7 @@ export const PeerConnection = {
             }
             conn.on('data', handler)
         })
+        hidePin()
         if (!accepted) throw new Error('Transfer rejected')
 
         const start = Date.now()


### PR DESCRIPTION
## Summary
- show connection pin until authentication completes
- improve error message when sending files
- allow `handleConnectOtherPeer` to accept a scanned ID
- default QR scanner to front camera and connect using scanned ID

## Testing
- `yarn test --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_6841b4cd4884832f83aa73b329b93e3a