### PR TITLE
Improve transfer speed display

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,8 +20,7 @@ import { assembleFile } from "./helpers/fileCache"; // Used for handleDownload (
 import { useAsyncState } from "./helpers/hooks"; // For fileList, sendLoading
 import download from "js-file-download"; // Used for handleDownload (now in ReceivedFilesCard)
 import { ReceivedFile } from "./store/connection/connectionTypes"; // Type for handleDownload (now in ReceivedFilesCard)
-// formatSpeed might be used in SendFileCard or ReceivedFilesCard if they display speed directly.
-// import { formatSpeed } from "./helpers/format";
+import { formatSpeed } from "./helpers/format";
 
 // Import new components
 import MainHeader from './components/MainHeader';
@@ -196,7 +195,7 @@ export const App: React.FC = () => {
                 sendLoading={sendLoading}
                 sendProgress={sendProgress} // Pass progress state
                 // sendInfo={sendInfo ? `Speed: ${formatSpeed(sendInfo.speed)}, Remaining: ${sendInfo.remaining.toFixed(1)}s` : null} // Format info here or in card
-                sendInfoString={sendInfo ? `Sent: ${(sendInfo.sent / (1024*1024)).toFixed(2)}MB / ${(sendInfo.total / (1024*1024)).toFixed(2)}MB | Speed: ${sendInfo.speed > 0 ? sendInfo.speed + ' MB/s' : 'Calculating...'} | ETA: ${sendInfo.remaining > 0 ? sendInfo.remaining.toFixed(1) + 's' : '-'}` : null}
+                sendInfoString={sendInfo ? `Sent: ${(sendInfo.sent / (1024*1024)).toFixed(2)}MB / ${(sendInfo.total / (1024*1024)).toFixed(2)}MB | Speed: ${sendInfo.speed > 0 ? formatSpeed(sendInfo.speed) : 'Calculating...'} | ETA: ${sendInfo.remaining > 0 ? sendInfo.remaining.toFixed(1) + 's' : '-'}` : null}
                 // connections={connectionStoreState.list} // Handled by SendFileCard's useSelector
                 // selectedConnectionId={connectionStoreState.selectedId} // Pass if used for targeting send
                 // onSelectConnectionTarget={(id) => dispatch(connectionAction.selectItem(id))} // Or manage target selection locally in SendFileCard

--- a/src/components/ReceivedFilesCard.tsx
+++ b/src/components/ReceivedFilesCard.tsx
@@ -128,7 +128,17 @@ const ReceivedFilesCard: React.FC = () => {
                   <div>
                     {file.fileType && <Tag style={{ marginRight: !file.ready && file.received < file.chunks ? 8 : 0 }}>{file.fileType}</Tag>}
                     {!file.ready && file.received < file.chunks && (
-                      <Progress percent={(file.received / file.chunks) * 100} size="small" style={{width: file.fileType ? 'calc(100% - 60px)' : '100%', display:'inline-block'}} />
+                      <Progress
+                        percent={(file.received / file.chunks) * 100}
+                        size="small"
+                        format={() => {
+                          const elapsed = file.startTime ? (Date.now() - file.startTime) / 1000 : 0;
+                          const receivedBytes = (file.size / file.chunks) * file.received;
+                          const speed = elapsed > 0 ? receivedBytes / elapsed : 0;
+                          return `${formatSpeed(speed)}`;
+                        }}
+                        style={{width: file.fileType ? 'calc(100% - 60px)' : '100%', display:'inline-block'}}
+                      />
                     )}
                   </div>
                 </Space>

--- a/src/components/SendFileCard.tsx
+++ b/src/components/SendFileCard.tsx
@@ -126,8 +126,15 @@ const SendFileCard: React.FC<SendFileCardProps> = ({
   };
 
   const renderStatus = () => {
-    if (sendLoading && sendProgress > 0) {
-      return <Progress percent={sendProgress} style={{ width: '100%' }} />;
+    if (sendLoading) {
+      return (
+        <>
+          <Progress percent={sendProgress} status="active" style={{ width: '100%' }} />
+          {sendInfoString && (
+            <Text type="secondary">{sendInfoString}</Text>
+          )}
+        </>
+      );
     }
     if (!sendLoading && averageSendSpeed !== null && totalSendTime !== null) {
       const successMessage = `File sent! Avg speed: ${formatSpeed(averageSendSpeed)}, Time: ${formatDuration(totalSendTime)}.`;


### PR DESCRIPTION
## Summary
- import formatSpeed helper
- show transfer speed during sending in SendFileCard
- display progress speed for received files
- fix speed formatting in App

## Testing
- `yarn test --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_6849d20a7af0832fb9548566ab2e293e