### PR TITLE
Improve transfer completion sync

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,6 @@
 // src/config.ts
-export const MAX_FILE_SIZE_MB = 100; // Default max file size to 100MB
+// Increase max file size to 100GB (expressed in MB)
+export const MAX_FILE_SIZE_MB = 100 * 1024;
 export const CHUNK_SIZE = 16 * 1024; // 16KB, a common chunk size
 
 // PeerJS server configuration (optional, defaults to PeerJS public cloud if not set)

--- a/src/helpers/peer.ts
+++ b/src/helpers/peer.ts
@@ -8,6 +8,7 @@ export enum DataType {
     FILE_CHUNK = 'FILE_CHUNK',
     FILE_CHUNK_ACK = 'FILE_CHUNK_ACK',
     FILE_COMPLETE = 'FILE_COMPLETE',
+    FILE_COMPLETE_ACK = 'FILE_COMPLETE_ACK',
     FILE_REQUEST = 'FILE_REQUEST',
     PIN_ACCEPT = 'PIN_ACCEPT',
     PIN_REJECT = 'PIN_REJECT'
@@ -213,6 +214,19 @@ export const PeerConnection = {
         await PeerConnection.sendConnection(id, {
             dataType: DataType.FILE_COMPLETE,
             fileName: file.name
+        })
+
+        await new Promise<void>((resolve) => {
+            const conn = connectionMap.get(id)
+            if (!conn) {resolve(); return}
+            const handler = (receivedData: any) => {
+                const d = receivedData as Data
+                if (d.dataType === DataType.FILE_COMPLETE_ACK && d.fileName === file.name) {
+                    conn.off('data', handler)
+                    resolve()
+                }
+            }
+            conn.on('data', handler)
         })
     },
     onConnectionReceiveData: (id: string, callback: (f: Data) => void) => {

--- a/src/store/connection/connectionActions.ts
+++ b/src/store/connection/connectionActions.ts
@@ -110,6 +110,7 @@ export const connectPeer: (id: string) => (dispatch: Dispatch, getState: () => a
                     // Fallback if startTime or size isn't available for some reason, just mark ready
                     dispatch(markFileReady(fileId));
                 }
+                PeerConnection.sendConnection(id, { dataType: DataType.FILE_COMPLETE_ACK, fileName: data.fileName });
             } else if (data.dataType === DataType.FILE && data.file) {
                 const fileId = `${id}-${data.fileName}`
                 const received: ReceivedFile = {


### PR DESCRIPTION
## Summary
- wait for receiver `FILE_COMPLETE_ACK` before finishing send
- reply with `FILE_COMPLETE_ACK` when transfer finalizes
- expand allowed upload size to 100 GB

## Testing
- `yarn test --watchAll=false` *(fails: package not in lockfile)*
- `yarn build` *(fails: package not in lockfile)*
- `npx tsc --noEmit` *(fails: cannot find module declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6849d63e9424832fa7e01b9fce57a808