### PR TITLE
Update file size units and add desktop layout tweaks

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -158,7 +158,7 @@ export const App: React.FC = () => {
             </Col>
         </Row>
         <Row gutter={[16, 16]} justify="center">
-          <Col xs={24} sm={24} md={8} lg={8} xl={6}>
+          <Col xs={24} sm={24} md={8} lg={8} xl={6} className="desktop-col">
             <SessionInfoCard
               // Props passed to SessionInfoCard
               // peerId={peerStoreState.id} // Handled by SessionInfoCard's useSelector
@@ -186,7 +186,7 @@ export const App: React.FC = () => {
           </Col>
 
           {peerStoreState.started && connectionStoreState.list.length > 0 && (
-            <Col xs={24} sm={24} md={8} lg={8} xl={6}>
+            <Col xs={24} sm={24} md={8} lg={8} xl={6} className="desktop-col">
               <SendFileCard
                 // Props for SendFileCard
                 fileList={fileList}
@@ -221,7 +221,7 @@ export const App: React.FC = () => {
           {/* LogViewer could be a third column or below, depending on layout preference */}
           {/* For now, keeping a similar 3-column structure if all cards are active */}
            {peerStoreState.started && (
-            <Col xs={24} sm={24} md={8} lg={8} xl={6}>
+            <Col xs={24} sm={24} md={8} lg={8} xl={6} className="desktop-col">
               {/* Placeholder for LogViewer if it's a separate component */}
               {/* <LogViewer /> */}
             </Col>

--- a/src/components/SendFileCard.tsx
+++ b/src/components/SendFileCard.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react'; // Added useState, useEffect
 import { Card, Button, Upload, message, Typography, Progress, Alert, Select, Empty, Space } from 'antd';
 import { SendOutlined, PaperClipOutlined } from '@ant-design/icons';
 import type { UploadFile, UploadProps } from 'antd/es/upload/interface';
-import { MAX_FILE_SIZE_MB } from '../config';
+import { MAX_FILE_SIZE_GB } from '../config';
 import { formatSpeed, formatDuration } from '../helpers/format'; // Import helpers
 
 const { Paragraph, Text } = Typography; // Added Text
@@ -60,8 +60,8 @@ const SendFileCard: React.FC<SendFileCardProps> = ({
         message.error('You can only send one file at a time.');
         return Upload.LIST_IGNORE;
       }
-      if (file.size > MAX_FILE_SIZE_MB * 1024 * 1024) {
-        message.error(`File is too large. Max size: ${MAX_FILE_SIZE_MB}MB. Please select a smaller file.`);
+      if (file.size > MAX_FILE_SIZE_GB * 1024 * 1024 * 1024) {
+        message.error(`File is too large. Max size: ${MAX_FILE_SIZE_GB}GB. Please select a smaller file.`);
         return Upload.LIST_IGNORE;
       }
       setFileList([file]);
@@ -172,7 +172,7 @@ const SendFileCard: React.FC<SendFileCardProps> = ({
 
           <Upload {...uploadAntProps} disabled={disabled || sendLoading || !selectedTargetId} style={{width: '100%'}}>
             <Button icon={<PaperClipOutlined />} disabled={disabled || sendLoading || !selectedTargetId} block>
-              Select File (Max {MAX_FILE_SIZE_MB}MB)
+              Select File (Max {MAX_FILE_SIZE_GB}GB)
             </Button>
           </Upload>
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,6 @@
 // src/config.ts
-// Increase max file size to 100GB (expressed in MB)
-export const MAX_FILE_SIZE_MB = 100 * 1024;
+// Maximum allowable file size in gigabytes
+export const MAX_FILE_SIZE_GB = 100;
 export const CHUNK_SIZE = 16 * 1024; // 16KB, a common chunk size
 
 // PeerJS server configuration (optional, defaults to PeerJS public cloud if not set)

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -8,6 +8,7 @@ import {ThemeProvider} from './theme/ThemeProvider';
 import 'antd/dist/reset.css';
 import './theme/glassmorphism.css'; // Import custom glassmorphism styles
 import './theme/animations.css'; // Import custom animation styles
+import './theme/responsive.css'; // Desktop layout tweaks
 
 const root = ReactDOM.createRoot(
     document.getElementById('root') as HTMLElement

--- a/src/theme/responsive.css
+++ b/src/theme/responsive.css
@@ -1,0 +1,6 @@
+@media (min-width: 992px) {
+  .desktop-col {
+    flex: 0 0 360px;
+    max-width: 360px;
+  }
+}


### PR DESCRIPTION
## Summary
- express upload limit in gigabytes in config
- show GB-based limit in file upload messages
- tweak columns for desktop via new CSS and class names
- load responsive CSS in app entry

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_6849d95510a8832f8e9f2f10262e0658